### PR TITLE
GPII-2080: Fix tests in Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "infusion": "2.0.0-dev.20160911T222604Z.b86ecbb",
-        "kettle": "1.1.0"
+        "kettle": "1.1.1"
     },
     "devDependencies": {
         "eslint-config-fluid": "1.0.0",

--- a/tests/WriteDefaultsTests.js
+++ b/tests/WriteDefaultsTests.js
@@ -158,7 +158,14 @@ gpii.tests.nexus.writeDefaults.testDefs = [
                 listener: "kettle.test.assertErrorResponse",
                 args: [{
                     message: "Write Defaults returns 400 for badly formed JSON",
-                    errorTexts: "Unexpected end of input",
+                    // In Node 4, parsing JSON that is not properly closed
+                    // results in the error message "Unexpected end of input".
+                    // In Node 6, the message was changed to "Unexpected end
+                    // of JSON input".
+                    // Here we test for "Unexpected end of" so that the test
+                    // works as expected in both Node 4 and Node 6.
+                    // https://issues.gpii.net/browse/GPII-2080
+                    errorTexts: "Unexpected end of",
                     string: "{arguments}.0",
                     request: "{writeDefaultsRequest}",
                     statusCode: 400


### PR DESCRIPTION
Update our test for parsing not properly closed JSON to accommodate a change
in error messaging in Node 6.

Also, update Kettle to version 1.1.1.