### PR TITLE
GPII-2488: Focus on a particular section of the component tree rooted at a "nexusComponentRoot"

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,3 +16,4 @@ var fluid = require("infusion");
 
 fluid.module.register("gpii-nexus", __dirname, require);
 require("./src/Nexus.js");
+require("./src/NexusUtils.js");

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "test": "node tests/all-tests.js"
     },
     "dependencies": {
-        "infusion": "2.0.0-dev.20160911T222604Z.b86ecbb",
+        "infusion": "2.0.0",
         "kettle": "1.1.1"
     },
     "devDependencies": {

--- a/src/Nexus.js
+++ b/src/Nexus.js
@@ -92,7 +92,7 @@ fluid.defaults("gpii.nexus.constructComponent.handler", {
     invokers: {
         handleRequest: {
             funcName: "gpii.nexus.constructComponent.handleRequest",
-            args: ["{request}.req.params.path", "{request}", "{nexusComponentRoot}"]
+            args: ["{request}.req.params.path", "{request}", "{gpii.nexus}.nexusComponentRoot"]
         }
     }
 });
@@ -109,7 +109,7 @@ fluid.defaults("gpii.nexus.destroyComponent.handler", {
     invokers: {
         handleRequest: {
             funcName: "gpii.nexus.destroyComponent.handleRequest",
-            args: ["{request}.req.params.path", "{request}", "{nexusComponentRoot}"]
+            args: ["{request}.req.params.path", "{request}", "{gpii.nexus}.nexusComponentRoot"]
         }
     }
 });
@@ -152,7 +152,7 @@ fluid.defaults("gpii.nexus.bindModel.handler", {
                 "{request}.req.params.componentPath",
                 "{request}.req.params.modelPath",
                 "{that}.targetModelChangeListener",
-                "{nexusComponentRoot}"
+                "{gpii.nexus}.nexusComponentRoot"
             ]
         },
         onReceiveMessage: {

--- a/src/NexusUtils.js
+++ b/src/NexusUtils.js
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 OCAD University
+
+Licensed under the New BSD license. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the License at
+https://raw.githubusercontent.com/GPII/nexus/master/LICENSE.txt
+*/
+
+/* eslint-env node */
+
+"use strict";
+
+var fluid = require("infusion"),
+    gpii = fluid.registerNamespace("gpii");
+
+fluid.registerNamespace("gpii.nexus");
+
+gpii.nexus.absComponentPath = function (container, path) {
+    var segs = (typeof(path) === "string" ? fluid.pathUtil.parseEL(path) : path);
+    var containerPath = fluid.pathForComponent(container);
+    return fluid.makeArray(containerPath).concat(segs);
+};
+
+gpii.nexus.componentForPathInContainer = function (container, path) {
+    return fluid.componentForPath(gpii.nexus.absComponentPath(container, path));
+};
+
+gpii.nexus.containsComponent = function (container, path) {
+    return fluid.isValue(gpii.nexus.componentForPathInContainer(container, path));
+};
+
+gpii.nexus.constructInContainer = function (container, path, options) {
+    return fluid.construct(gpii.nexus.absComponentPath(container, path), options);
+};
+
+gpii.nexus.destroyInContainer = function (container, path) {
+    return fluid.destroy(gpii.nexus.absComponentPath(container, path));
+};

--- a/src/test/NexusTestUtils.js
+++ b/src/test/NexusTestUtils.js
@@ -53,14 +53,6 @@ gpii.test.nexus.assertContainsComponent = function (componentRoot, parentPath, c
     jqUnit.assertValue(parentPath + " component contains " + childName, parent[childName]);
 };
 
-gpii.test.nexus.changeModelAtPath = function (componentPath, modelPath, value) {
-    fluid.componentForPath(componentPath).applier.change(modelPath, value);
-};
-
-gpii.test.nexus.changeEventForComponent = function (path) {
-    return fluid.componentForPath(path).applier.modelChanged;
-};
-
 fluid.defaults("gpii.test.nexus.testCaseHolder", {
     gradeNames: "kettle.test.testCaseHolder",
     components: {

--- a/src/test/NexusTestUtils.js
+++ b/src/test/NexusTestUtils.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2015, 2016 OCAD University
+Copyright 2015, 2016, 2017 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
@@ -33,25 +33,32 @@ gpii.test.nexus.verifyReadDefaultsResponse = function (body, request, expectedGr
     jqUnit.assertLeftHand("Response has expected grade specification", expectedGradeSpec, responseGradeSpec);
 };
 
-gpii.test.nexus.assertNoComponentAtPath = function (message, path) {
-    var component = fluid.componentForPath(path);
-    jqUnit.assertNoValue(message, component);
+gpii.test.nexus.assertNoComponentAtPath = function (message, componentRoot, path) {
+    jqUnit.assertFalse(message, gpii.nexus.containsComponent(componentRoot, path));
 };
 
-gpii.test.nexus.assertComponentModel = function (message, path, expectedModel) {
-    var component = fluid.componentForPath(path);
+gpii.test.nexus.assertComponentModel = function (message, componentRoot, path, expectedModel) {
+    var component = gpii.nexus.componentForPathInContainer(componentRoot, path);
     jqUnit.assertValue("Component exists", component);
     jqUnit.assertDeepEq(message, expectedModel, component.model);
 };
 
-gpii.test.nexus.assertNotContainsComponent = function (parentPath, childName) {
-    var parent = fluid.componentForPath(parentPath);
+gpii.test.nexus.assertNotContainsComponent = function (componentRoot, parentPath, childName) {
+    var parent = gpii.nexus.componentForPathInContainer(componentRoot, parentPath);
     jqUnit.assertNoValue(parentPath + " component does not contain " + childName, parent[childName]);
 };
 
-gpii.test.nexus.assertContainsComponent = function (parentPath, childName) {
-    var parent = fluid.componentForPath(parentPath);
+gpii.test.nexus.assertContainsComponent = function (componentRoot, parentPath, childName) {
+    var parent = gpii.nexus.componentForPathInContainer(componentRoot, parentPath);
     jqUnit.assertValue(parentPath + " component contains " + childName, parent[childName]);
+};
+
+gpii.test.nexus.changeModelAtPath = function (componentPath, modelPath, value) {
+    fluid.componentForPath(componentPath).applier.change(modelPath, value);
+};
+
+gpii.test.nexus.changeEventForComponent = function (path) {
+    return fluid.componentForPath(path).applier.modelChanged;
 };
 
 fluid.defaults("gpii.test.nexus.testCaseHolder", {

--- a/tests/BindModelTests.js
+++ b/tests/BindModelTests.js
@@ -34,7 +34,7 @@ gpii.tests.nexus.bindModel.componentOptions = {
     }
 };
 
-gpii.tests.nexus.bindModel.registerModelListenerForPath = function (nexusComponentRoot,componentPath, modelPath, event) {
+gpii.tests.nexus.bindModel.registerModelListenerForPath = function (nexusComponentRoot, componentPath, modelPath, event) {
     var component = gpii.nexus.componentForPathInContainer(nexusComponentRoot, componentPath);
     component.applier.modelChanged.addListener(modelPath, event.fire);
 };

--- a/tests/BindModelTests.js
+++ b/tests/BindModelTests.js
@@ -34,8 +34,8 @@ gpii.tests.nexus.bindModel.componentOptions = {
     }
 };
 
-gpii.tests.nexus.bindModel.registerModelListenerForPath = function (componentPath, modelPath, event) {
-    var component = fluid.componentForPath(componentPath);
+gpii.tests.nexus.bindModel.registerModelListenerForPath = function (nexusComponentRoot,componentPath, modelPath, event) {
+    var component = gpii.nexus.componentForPathInContainer(nexusComponentRoot, componentPath);
     component.applier.modelChanged.addListener(modelPath, event.fire);
 };
 
@@ -50,6 +50,11 @@ fluid.defaults("gpii.tests.nexus.bindModel.wsClient", {
 });
 
 // TODO: Test with multiple connected WebSocket clients
+
+// Note that these tests verify steps by peeking into the Nexus internal
+// state. This is done by making the nexusComponentRoot addressable by
+// giving it the grades "gpii.tests.nexus.componentRoot" and
+// "fluid.resolveRoot" in the test Kettle app config.
 
 gpii.tests.nexus.bindModel.testDefs = [
     {
@@ -73,7 +78,11 @@ gpii.tests.nexus.bindModel.testDefs = [
         sequence: [
             {
                 func: "gpii.test.nexus.assertNoComponentAtPath",
-                args: ["Component not yet constructed", "{tests}.options.testComponentPath"]
+                args: [
+                    "Component not yet constructed",
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath"
+                ]
             },
             {
                 func: "{constructComponentRequest}.send",
@@ -87,6 +96,7 @@ gpii.tests.nexus.bindModel.testDefs = [
             {
                 func: "gpii.tests.nexus.bindModel.registerModelListenerForPath",
                 args: [
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
                     "{tests}.options.testModelPath",
                     "{testCaseHolder}.events.targetModelChanged"
@@ -125,6 +135,7 @@ gpii.tests.nexus.bindModel.testDefs = [
                 listener: "gpii.test.nexus.assertComponentModel",
                 args: [
                     "Model updated",
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
                     {
                         "model.path\\seg1": {
@@ -163,6 +174,7 @@ gpii.tests.nexus.bindModel.testDefs = [
                 listener: "gpii.test.nexus.assertComponentModel",
                 args: [
                     "Model updated",
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
                     {
                         "model.path\\seg1": {
@@ -207,6 +219,7 @@ gpii.tests.nexus.bindModel.testDefs = [
                 listener: "gpii.test.nexus.assertComponentModel",
                 args: [
                     "Model updated",
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
                     {
                         "model.path\\seg1": {

--- a/tests/BindModelTests.js
+++ b/tests/BindModelTests.js
@@ -34,8 +34,8 @@ gpii.tests.nexus.bindModel.componentOptions = {
     }
 };
 
-gpii.tests.nexus.bindModel.registerModelListenerForPath = function (nexusComponentRoot, componentPath, modelPath, event) {
-    var component = gpii.nexus.componentForPathInContainer(nexusComponentRoot, componentPath);
+gpii.tests.nexus.bindModel.registerModelListenerForPath = function (componentRoot, componentPath, modelPath, event) {
+    var component = gpii.nexus.componentForPathInContainer(componentRoot, componentPath);
     component.applier.modelChanged.addListener(modelPath, event.fire);
 };
 

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -37,6 +37,11 @@ gpii.tests.nexus.constructComponent.componentOptions2 = {
     }
 };
 
+// Note that these tests verify steps by peeking into the Nexus internal
+// state. This is done by making the nexusComponentRoot addressable by
+// giving it the grades "gpii.tests.nexus.componentRoot" and
+// "fluid.resolveRoot" in the test Kettle app config.
+
 gpii.tests.nexus.constructComponent.testDefs = [
     {
         name: "Construct and Destroy Components",
@@ -63,11 +68,19 @@ gpii.tests.nexus.constructComponent.testDefs = [
         sequence: [
             {
                 func: "gpii.test.nexus.assertNoComponentAtPath",
-                args: ["Component not yet constructed", "{tests}.options.testComponentPath"]
+                args: [
+                    "Component not yet constructed",
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath"
+                ]
             },
             {
                 func: "gpii.test.nexus.assertNoComponentAtPath",
-                args: ["Component not yet constructed", "{tests}.options.testComponentPath2"]
+                args: [
+                    "Component not yet constructed",
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath2"
+                ]
             },
             // Construct component one
             {
@@ -83,6 +96,7 @@ gpii.tests.nexus.constructComponent.testDefs = [
                 func: "gpii.test.nexus.assertComponentModel",
                 args: [
                     "Model is as expected",
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
                     gpii.tests.nexus.constructComponent.componentOptions1.model
                 ]
@@ -90,7 +104,11 @@ gpii.tests.nexus.constructComponent.testDefs = [
             // Construct component two
             {
                 func: "gpii.test.nexus.assertNotContainsComponent",
-                args: ["{tests}.options.testComponentPath", "{tests}.options.testComponentName2"]
+                args: [
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath",
+                    "{tests}.options.testComponentName2"
+                ]
             },
             {
                 func: "{constructComponentRequest2}.send",
@@ -105,13 +123,18 @@ gpii.tests.nexus.constructComponent.testDefs = [
                 func: "gpii.test.nexus.assertComponentModel",
                 args: [
                     "Model is as expected",
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath2",
                     gpii.tests.nexus.constructComponent.componentOptions2.model
                 ]
             },
             {
                 func: "gpii.test.nexus.assertContainsComponent",
-                args: ["{tests}.options.testComponentPath", "{tests}.options.testComponentName2"]
+                args: [
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath",
+                    "{tests}.options.testComponentName2"
+                ]
             },
             // Destroy component two
             {
@@ -124,17 +147,26 @@ gpii.tests.nexus.constructComponent.testDefs = [
             },
             {
                 func: "gpii.test.nexus.assertNoComponentAtPath",
-                args: ["Component has been destroyed", "{tests}.options.testComponentPath2"]
+                args: [
+                    "Component has been destroyed",
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath2"
+                ]
             },
             {
                 func: "gpii.test.nexus.assertNotContainsComponent",
-                args: ["{tests}.options.testComponentPath", "{tests}.options.testComponentName2"]
+                args: [
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath",
+                    "{tests}.options.testComponentName2"
+                ]
             },
             // Destroy component one
             {
                 func: "gpii.test.nexus.assertComponentModel",
                 args: [
                     "Model is as expected",
+                    "{gpii.tests.nexus.componentRoot}",
                     "{tests}.options.testComponentPath",
                     gpii.tests.nexus.constructComponent.componentOptions1.model
                 ]
@@ -149,7 +181,11 @@ gpii.tests.nexus.constructComponent.testDefs = [
             },
             {
                 func: "gpii.test.nexus.assertNoComponentAtPath",
-                args: ["Component has been destroyed", "{tests}.options.testComponentPath"]
+                args: [
+                    "Component has been destroyed",
+                    "{gpii.tests.nexus.componentRoot}",
+                    "{tests}.options.testComponentPath"
+                ]
             }
         ]
     }

--- a/tests/NexusUtilsTests.js
+++ b/tests/NexusUtilsTests.js
@@ -1,0 +1,162 @@
+/*
+Copyright 2017 OCAD University
+
+Licensed under the New BSD license. You may not use this file except in
+compliance with this License.
+
+You may obtain a copy of the License at
+https://raw.githubusercontent.com/GPII/nexus/master/LICENSE.txt
+*/
+
+/* eslint-env node */
+
+"use strict";
+
+var fluid = require("infusion"),
+    gpii = fluid.registerNamespace("gpii"),
+    jqUnit = fluid.require("node-jqunit");
+
+require("../index.js");
+
+jqUnit.module("NexusUtils Tests");
+
+fluid.defaults("gpii.tests.nexus.nexusUtils.parent", {
+    gradeNames: ["fluid.component", "fluid.resolveRoot"],
+    components: {
+        container: {
+            type: "fluid.component",
+            options: {
+                components: {
+                    componentA: {
+                        type: "fluid.component",
+                        options: {
+                            components: {
+                                componentA1: {
+                                    type: "fluid.component"
+                                }
+                            }
+                        }
+                    },
+                    componentB: {
+                        type: "fluid.component",
+                        options: {
+                            listeners: {
+                                afterDestroy: "{gpii.tests.nexus.nexusUtils.parent}.events.onComponentBDestroyed"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    events: {
+        onComponentBDestroyed: null
+    }
+});
+
+fluid.defaults("gpii.tests.nexus.nexusUtils.newComponent", {
+    gradeNames: "fluid.component",
+    newComponentName: null, // Will be provided by construction caller
+    listeners: {
+        onCreate: {
+            funcName: "gpii.tests.nexus.nexusUtils.verifyNewComponent",
+            args: [
+                "{gpii.tests.nexus.nexusUtils.parent}.container",
+                "{that}.options.newComponentName"
+            ]
+        }
+    }
+});
+
+gpii.tests.nexus.nexusUtils.verifyNewComponent = function (container, newComponentName) {
+    jqUnit.assertTrue("The new component exists in container",
+        gpii.nexus.containsComponent(container, newComponentName));
+    jqUnit.assertTrue("The new component has the expected grade",
+        fluid.componentHasGrade(gpii.nexus.componentForPathInContainer(container, newComponentName),
+            "gpii.tests.nexus.nexusUtils.newComponent"));
+    jqUnit.start();
+};
+
+jqUnit.test("absComponentPath", function () {
+    jqUnit.expect(1);
+
+    var parent = fluid.construct("nexusUtilsTestParent", {
+        type: "gpii.tests.nexus.nexusUtils.parent"
+    });
+
+    jqUnit.assertDeepEq("absComponentPath",
+        ["nexusUtilsTestParent", "container", "componentA"],
+        gpii.nexus.absComponentPath(parent.container, "componentA"));
+});
+
+jqUnit.test("componentForPathInContainer", function () {
+    jqUnit.expect(4);
+
+    var parent = gpii.tests.nexus.nexusUtils.parent();
+
+    jqUnit.assertEquals("Top level component, path as string", parent.container.componentA,
+        gpii.nexus.componentForPathInContainer(parent.container, "componentA"));
+
+    jqUnit.assertEquals("Top level component, path as array", parent.container.componentA,
+        gpii.nexus.componentForPathInContainer(parent.container, ["componentA"]));
+
+    jqUnit.assertEquals("Second level component, path as string", parent.container.componentA.componentA1,
+        gpii.nexus.componentForPathInContainer(parent.container, "componentA.componentA1"));
+
+    jqUnit.assertEquals("Second level component, path as array", parent.container.componentA.componentA1,
+        gpii.nexus.componentForPathInContainer(parent.container, ["componentA", "componentA1"]));
+});
+
+jqUnit.test("containsComponent", function () {
+    jqUnit.expect(7);
+
+    var parent = gpii.tests.nexus.nexusUtils.parent();
+
+    jqUnit.assertTrue("Contains top level component, path as string",
+        gpii.nexus.containsComponent(parent.container, "componentA"));
+
+    jqUnit.assertTrue("Contains top level component, path as array",
+        gpii.nexus.containsComponent(parent.container, ["componentA"]));
+
+    jqUnit.assertTrue("Contains second level component, path as string",
+        gpii.nexus.containsComponent(parent.container, "componentA.componentA1"));
+
+    jqUnit.assertTrue("Contains second level component, path as array",
+        gpii.nexus.containsComponent(parent.container, ["componentA", "componentA1"]));
+
+    jqUnit.assertFalse("Does not contain top level component",
+        gpii.nexus.containsComponent(parent.container, "nonExistingComponent"));
+
+    jqUnit.assertFalse("Does not contain top level component, with subcomponent",
+        gpii.nexus.containsComponent(parent.container, "nonExistingComponent.subcomponent"));
+
+    jqUnit.assertFalse("Does not contain second level component",
+        gpii.nexus.containsComponent(parent.container, "componentA.nonExistingComponent"));
+});
+
+jqUnit.asyncTest("constructInContainer", function () {
+    jqUnit.expect(3);
+
+    var parent = gpii.tests.nexus.nexusUtils.parent();
+
+    jqUnit.assertFalse("newComponent does not exist",
+        gpii.nexus.containsComponent(parent.container, "newComponent"));
+
+    gpii.nexus.constructInContainer(parent.container, "newComponent", {
+        type: "gpii.tests.nexus.nexusUtils.newComponent",
+        newComponentName: "newComponent"
+    });
+});
+
+jqUnit.asyncTest("destroyInContainer", function () {
+    jqUnit.expect(1);
+
+    var parent = gpii.tests.nexus.nexusUtils.parent({
+        listeners: {
+            onComponentBDestroyed: "jqUnit.start"
+        }
+    });
+
+    jqUnit.assertTrue("componentB exists initially", gpii.nexus.containsComponent(parent.container, "componentB"));
+    gpii.nexus.destroyInContainer(parent.container, "componentB");
+});

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -17,6 +17,7 @@ var fluid = require("infusion");
 var tests = [
     "./BindModelTests.js",
     "./ConstructAndDestroyComponentTests.js",
+    "./NexusUtilsTests.js",
     "./ReadDefaultsTests.js",
     "./WriteDefaultsTests.js"
 ];

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2015, 2016 OCAD University
+Copyright 2015, 2016, 2017 OCAD University
 
 Licensed under the New BSD license. You may not use this file except in
 compliance with this License.
@@ -15,10 +15,10 @@ https://raw.githubusercontent.com/GPII/nexus/master/LICENSE.txt
 var fluid = require("infusion");
 
 var tests = [
-    "./ReadDefaultsTests.js",
-    "./WriteDefaultsTests.js",
+    "./BindModelTests.js",
     "./ConstructAndDestroyComponentTests.js",
-    "./BindModelTests.js"
+    "./ReadDefaultsTests.js",
+    "./WriteDefaultsTests.js"
 ];
 
 fluid.each(tests, function (path) {

--- a/tests/configs/gpii.tests.nexus.config.json
+++ b/tests/configs/gpii.tests.nexus.config.json
@@ -10,7 +10,18 @@
                     "port": "{kettle.config}.options.serverPort",
                     "components": {
                         "nexus": {
-                            "type": "gpii.nexus"
+                            "type": "gpii.nexus",
+                            "options": {
+                                "distributeOptions": [
+                                    {
+                                        "target": "{that nexusComponentRoot}.options.gradeNames",
+                                        "record": [
+                                            "gpii.tests.nexus.componentRoot",
+                                            "fluid.resolveRoot"
+                                        ]
+                                    }
+                                ]
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This pull request changes the Nexus to operate on a section of the component tree rooted at a "nexusComponentRoot".

It adds a new subcomponent to the Nexus called "nexusComponentRoot" together with utility functions for operating on component paths within a container:

- `gpii.nexus.componentForPathInContainer()` (`fluid.componentForPath()`)
- `gpii.nexus.constructInContainer()` (`fluid.construct()`)
- `gpii.nexus.destroyInContainer()` (`fluid.destroy()`)
- `gpii.nexus.containsComponent()`

These utility functions are used in the Nexus to constrain operation to the "nexusComponentRoot", rather than using the underlying functions (`fluid.construct()` and such) directly.

This work was originally done as part of adding the Co-Occurrence Engine to the Nexus. The Co-Occurrence Engine has now been moved to its own repository:

https://github.com/simonbates/co-occurrence-engine

The Co-Occurrence Engine also makes use of the above utility functions when monitoring the nexusComponentRoot and constructing recipe products.
