### PR TITLE
NOJIRA - Fix Ansible inventory warning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,7 +61,7 @@ Vagrant.configure(2) do |config|
   # inclusivedesign/centos7 Vagrant box includes one.
   config.vm.provision "shell", inline: <<-SHELL
     sudo ansible-galaxy install -fr #{app_directory}/provisioning/requirements.yml
-    sudo PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure,deploy"
+    sudo PYTHONUNBUFFERED=1 ansible-playbook #{app_directory}/provisioning/playbook.yml --tags="install,configure,deploy" --inventory="localhost ansible_connection=local,"
   SHELL
 
   # 'Vagrantfile.local' should be excluded from version control.


### PR DESCRIPTION
Ansible used to include an inventory file that had "localhost". The default inventory now is empty and this warning is shown:

```
    default:  [WARNING]: provided hosts list is empty, only localhost is available. Note
    default: that the implicit localhost does not match 'all'
```

This shows in red in log output and can confuse users.

I'm proposing an inventory is defined on the fly through a command line parameter, just to satisfy Ansible and clean up the logs. This should be harmless.