### PR TITLE
Fluid 6511: Change component construction endpoint to use PUT, and add a component-reading endpoint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ node_modules
 
 # package lock file
 package-lock.json
+
+# VSCode files
+/.vscode/

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Prerequisites:
 In this example, we will construct a new component, register 2 model
 listeners, and send a model update.
 
-Start Nexus and make a POST request to construct a new component:
+Start Nexus and make a PUT request to construct a new component:
 
 ```
 $ vagrant up
-$ curl -H 'Content-Type: application/json' -d '{ "type": "fluid.modelComponent", "model": { "a": null } }' http://localhost:9081/components/example1
+$ curl -H 'Content-Type: application/json' -X PUT -d '{ "type": "fluid.modelComponent", "model": { "a": null } }' http://localhost:9081/components/example1
 ```
 
 Next we will make WebSocket Bind Model connections to the constructed component. Set up 2 connections by executing the following in 2 separate terminals:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "infusion-nexus",
-    "version": "0.5.0",
+    "version": "1.0.0",
     "author": "fluid-project",
     "license": "BSD-3-Clause",
     "repository": "git@github.com:fluid-project/nexus.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "infusion-nexus",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "author": "fluid-project",
     "license": "BSD-3-Clause",
     "repository": "git@github.com:fluid-project/nexus.git",

--- a/src/nexusGrades.js
+++ b/src/nexusGrades.js
@@ -102,20 +102,22 @@ fluid.defaults("fluid.nexus.readComponent.handler", {
     }
 });
 
-// TODO: this API endpoint should really supply the potentia and model of a component,
+// TODO: currently, we imagine this API endpoint exists mainly for testing. 
+//       In the future, the goal is to respond with the potentia and model of a component,
 //       i.e. serialized material that could be used to reconstruct the component in its current state.
-//       This is not straightforward to provide under the current version of Infusion.
+//       This will require some additional documentation and writeups of example use cases.
+//       The ongoing design of the Nexus API is discussed at https://wiki.fluidproject.org/display/fluid/Nexus+API+revisions
 /**
  * Retrieve a serialized version of a component's "shell" at a path, consisting of its construction status, typeName, model, and id.
  * @param {String} path the path to the component, can also be given as an array.
- * @param {Object} request the kettle.request.http component that will mediate the response.
- * @param {Object} nexusComponentRoot the component with grade nexusComponetRoot, which path is relative to.
+ * @param {kettle.request.http} request the request component that will mediate the response.
+ * @param {fluid.component} nexusComponentRoot the component with grade nexusComponentRoot, which path is relative to.
  */
 fluid.nexus.readComponent.handleRequest = function (path, request, nexusComponentRoot) {
     var component = fluid.nexus.componentForPathInContainer(nexusComponentRoot, path);
     if (component) {
         var componentShell = fluid.filterKeys(component, ["id", "lifecycleStatus", "model", "typeName"]);
-        request.events.onSuccess.fire(JSON.stringify(componentShell));
+        request.events.onSuccess.fire(componentShell);
     } else {
         request.events.onError.fire({
             message: "Component not found",

--- a/src/nexusGrades.js
+++ b/src/nexusGrades.js
@@ -33,9 +33,14 @@ fluid.defaults("fluid.nexus", {
             method: "put",
             type: "fluid.nexus.writeDefaults.handler"
         },
+        readComponent: {
+            route: "/components/:path",
+            method: "get",
+            type: "fluid.nexus.readComponent.handler"
+        },
         constructComponent: {
             route: "/components/:path",
-            method: "post",
+            method: "put",
             type: "fluid.nexus.constructComponent.handler"
         },
         destroyComponent: {
@@ -85,6 +90,35 @@ fluid.defaults("fluid.nexus.writeDefaults.handler", {
 fluid.nexus.writeDefaults.handleRequest = function (gradeName, request) {
     fluid.defaults(gradeName, request.req.body);
     request.events.onSuccess.fire();
+};
+
+fluid.defaults("fluid.nexus.readComponent.handler", {
+    gradeNames: ["kettle.request.http"],
+    invokers: {
+        handleRequest: {
+            funcName: "fluid.nexus.readComponent.handleRequest",
+            args: ["{request}.req.params.path", "{request}"]
+        }
+    }
+});
+
+fluid.nexus.readComponent.handleRequest = function (path, request) {
+    // looks like I need to determine if the path is to a component or not
+    // what gets us away from components?
+    //   events
+    //   model
+    //   options
+    //   
+    var component = fluid.componentForPath(path);
+    var value = fluid.getForComponent(component, "model.thing.thing");
+    if (value) {
+        request.events.onSuccess.fire(value);
+    } else {
+        request.events.onError.fire({
+            message: "Component or value not found",
+            statusCode: 404
+        });
+    }
 };
 
 fluid.defaults("fluid.nexus.constructComponent.handler", {

--- a/src/nexusGrades.js
+++ b/src/nexusGrades.js
@@ -102,7 +102,7 @@ fluid.defaults("fluid.nexus.readComponent.handler", {
     }
 });
 
-// TODO: currently, we imagine this API endpoint exists mainly for testing. 
+// TODO: currently, we imagine this API endpoint exists mainly for testing.
 //       In the future, the goal is to respond with the potentia and model of a component,
 //       i.e. serialized material that could be used to reconstruct the component in its current state.
 //       This will require some additional documentation and writeups of example use cases.

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -112,7 +112,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             options: {
                 path: "/components/%path",
                 port: "{configuration}.options.serverPort",
-                method: "POST",
+                method: "PUT",
                 termMap: {
                     path: "{tests}.options.testComponentPath"
                 }
@@ -123,7 +123,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             options: {
                 path: "/components/%path",
                 port: "{configuration}.options.serverPort",
-                method: "POST",
+                method: "PUT",
                 termMap: {
                     path: "{tests}.options.testComponentPath2"
                 }

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -54,6 +54,7 @@ fluid.test.nexus.assertContainsComponent = function (componentRoot, parentPath, 
 
 /**
  * Wrapper for jqUnit.assertLeftHand that parses the value to test.
+ * @param {String} message description of what is being asserted.
  * @param {Object} expected the expected keys and values.
  * @param {Object} actual the object to test.
  */
@@ -75,31 +76,31 @@ fluid.defaults("fluid.test.nexus.request.http", {
 fluid.defaults("fluid.test.nexus.readDefaultsRequest", {
     gradeNames: ["fluid.test.nexus.request.http"],
     path: "/defaults/%gradeName",
-    method: "GET",
+    method: "GET"
 });
 
 fluid.defaults("fluid.test.nexus.writeDefaultsRequest", {
     gradeNames: ["fluid.test.nexus.request.http"],
     path: "/defaults/%gradeName",
-    method: "PUT",
+    method: "PUT"
 });
 
 fluid.defaults("fluid.test.nexus.readComponentRequest", {
     gradeNames: ["fluid.test.nexus.request.http"],
     path: "/components/%componentPath",
-    method: "GET",
+    method: "GET"
 });
 
 fluid.defaults("fluid.test.nexus.constructComponentRequest", {
     gradeNames: ["fluid.test.nexus.request.http"],
     path: "/components/%componentPath",
-    method: "PUT",
+    method: "PUT"
 });
 
 fluid.defaults("fluid.test.nexus.destroyComponentRequest", {
     gradeNames: ["fluid.test.nexus.request.http"],
     path: "/components/%componentPath",
-    method: "DELETE",
+    method: "DELETE"
 });
 
 fluid.defaults("fluid.test.nexus.testCaseHolder", {

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -53,72 +53,59 @@ fluid.test.nexus.assertContainsComponent = function (componentRoot, parentPath, 
 };
 
 /**
- * Assert that the object toTest contains a set of keys with given values.
- * Can also be understood as "assert that the object expected is a subset of the object toTest".
+ * Wrapper for jqUnit.assertLeftHand that parses the value to test.
  * @param {Object} expected the expected keys and values.
  * @param {Object} actual the object to test.
  */
-fluid.test.nexus.assertKeyValues = function (expected, actual) {
-    for (var key in expected) {
-        var value = expected[key];
-        jqUnit.assertDeepEq(value, actual[key]);
-    }
+fluid.test.nexus.assertLeftHand = function (message, expected, actual) {
+    jqUnit.assertLeftHand(message, expected, JSON.parse(actual));
 };
 
-fluid.defaults("fluid.test.nexus.readDefaultsRequest", {
+// all test request grades communicate with a port defined by the test configuration,
+// and a path parameterized by either a gradeName or componentPath set in a termMap.
+fluid.defaults("fluid.test.nexus.request.http", {
     gradeNames: ["kettle.test.request.http"],
-    path: "/defaults/%gradeName",
     port: "{configuration}.options.serverPort",
-    method: "GET",
     termMap: {
-        gradeName: "fill in construction options"
+        gradeName: "fill in construction options",
+        componentPath: "fill in construction options"
     }
+});
+
+fluid.defaults("fluid.test.nexus.readDefaultsRequest", {
+    gradeNames: ["fluid.test.nexus.request.http"],
+    path: "/defaults/%gradeName",
+    method: "GET",
 });
 
 fluid.defaults("fluid.test.nexus.writeDefaultsRequest", {
-    gradeNames: ["kettle.test.request.http"],
+    gradeNames: ["fluid.test.nexus.request.http"],
     path: "/defaults/%gradeName",
-    port: "{configuration}.options.serverPort",
     method: "PUT",
-    termMap: {
-        gradeName: "fill in construction options"
-    }
 });
 
 fluid.defaults("fluid.test.nexus.readComponentRequest", {
-    gradeNames: ["kettle.test.request.http"],
-    path: "/components/%path",
-    port: "{configuration}.options.serverPort",
+    gradeNames: ["fluid.test.nexus.request.http"],
+    path: "/components/%componentPath",
     method: "GET",
-    termMap: {
-        path: "fill in construction options"
-    }
 });
 
 fluid.defaults("fluid.test.nexus.constructComponentRequest", {
-    gradeNames: ["kettle.test.request.http"],
-    path: "/components/%path",
-    port: "{configuration}.options.serverPort",
+    gradeNames: ["fluid.test.nexus.request.http"],
+    path: "/components/%componentPath",
     method: "PUT",
-    termMap: {
-        path: "fill in construction options"
-    }
 });
 
 fluid.defaults("fluid.test.nexus.destroyComponentRequest", {
-    gradeNames: ["kettle.test.request.http"],
-    path: "/components/%path",
-    port: "{configuration}.options.serverPort",
+    gradeNames: ["fluid.test.nexus.request.http"],
+    path: "/components/%componentPath",
     method: "DELETE",
-    termMap: {
-        path: "fill in construction options"
-    }
 });
 
 fluid.defaults("fluid.test.nexus.testCaseHolder", {
     gradeNames: "kettle.test.testCaseHolder",
     components: {
-        readDefaultsRequest: {
+        readDefaultsRequest1: {
             type: "fluid.test.nexus.readDefaultsRequest",
             options: {
                 termMap: {
@@ -126,7 +113,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
                 }
             }
         },
-        readDefaultsSecondTimeRequest: {
+        readDefaultsRequest2: {
             type: "fluid.test.nexus.readDefaultsRequest",
             options: {
                 termMap: {
@@ -134,7 +121,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
                 }
             }
         },
-        readDefaultsThirdTimeRequest: {
+        readDefaultsRequest3: {
             type: "fluid.test.nexus.readDefaultsRequest",
             options: {
                 termMap: {
@@ -142,7 +129,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
                 }
             }
         },
-        writeDefaultsRequest: {
+        writeDefaultsRequest1: {
             type: "fluid.test.nexus.writeDefaultsRequest",
             options: {
                 termMap: {
@@ -150,7 +137,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
                 }
             }
         },
-        writeDefaultsAgainRequest: {
+        writeDefaultsRequest2: {
             type: "fluid.test.nexus.writeDefaultsRequest",
             options: {
                 termMap: {
@@ -158,11 +145,11 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
                 }
             }
         },
-        constructComponentRequest: {
+        constructComponentRequest1: {
             type: "fluid.test.nexus.constructComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath"
+                    componentPath: "{tests}.options.testComponentPath"
                 }
             }
         },
@@ -170,15 +157,15 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             type: "fluid.test.nexus.constructComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath2"
+                    componentPath: "{tests}.options.testComponentPath2"
                 }
             }
         },
-        destroyComponentRequest: {
+        destroyComponentRequest1: {
             type: "fluid.test.nexus.destroyComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath"
+                    componentPath: "{tests}.options.testComponentPath"
                 }
             }
         },
@@ -186,7 +173,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             type: "fluid.test.nexus.destroyComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath2"
+                    componentPath: "{tests}.options.testComponentPath2"
                 }
             }
         },
@@ -194,7 +181,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             type: "fluid.test.nexus.readComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath"
+                    componentPath: "{tests}.options.testComponentPath"
                 }
             }
         },
@@ -202,7 +189,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             type: "fluid.test.nexus.readComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath"
+                    componentPath: "{tests}.options.testComponentPath"
                 }
             }
         },
@@ -210,7 +197,7 @@ fluid.defaults("fluid.test.nexus.testCaseHolder", {
             type: "fluid.test.nexus.readComponentRequest",
             options: {
                 termMap: {
-                    path: "{tests}.options.testComponentPath"
+                    componentPath: "{tests}.options.testComponentPath"
                 }
             }
         }

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -32,6 +32,23 @@ fluid.test.nexus.verifyReadDefaultsResponse = function (body, request, expectedG
     jqUnit.assertLeftHand("Response has expected grade specification", expectedGradeSpec, responseGradeSpec);
 };
 
+
+/**
+ * Verify that a response to the component reading endpoint is well-formed and has the expected content.
+ * @param {String} body the body of the HTTP response.
+ * @param {kettle.request.http} request the component representing the HTTP response.
+ * @param {Object} expectedComponentMaterial the expected content of the response body.
+ */
+fluid.test.nexus.verifyReadComponentResponse = function (body, request, expectedComponentMaterial) {
+    var responseComponentMaterial = JSON.parse(body);
+    var response = request.nativeResponse;
+    jqUnit.assertEquals("Response has status code 200", 200, response.statusCode);
+    jqUnit.assertTrue("Response has JSON content-type",
+                      response.headers["content-type"].indexOf("application/json") === 0);
+    jqUnit.assertLeftHand("Response has expected component material", expectedComponentMaterial,
+    responseComponentMaterial);
+};
+
 fluid.test.nexus.assertNoComponentAtPath = function (message, componentRoot, path) {
     jqUnit.assertFalse(message, fluid.nexus.containsComponent(componentRoot, path));
 };
@@ -50,16 +67,6 @@ fluid.test.nexus.assertNotContainsComponent = function (componentRoot, parentPat
 fluid.test.nexus.assertContainsComponent = function (componentRoot, parentPath, childName) {
     var parent = fluid.nexus.componentForPathInContainer(componentRoot, parentPath);
     jqUnit.assertValue(parentPath + " component contains " + childName, parent[childName]);
-};
-
-/**
- * Wrapper for jqUnit.assertLeftHand that parses the value to test.
- * @param {String} message description of what is being asserted.
- * @param {Object} expected the expected keys and values.
- * @param {Object} actual the object to test.
- */
-fluid.test.nexus.assertLeftHand = function (message, expected, actual) {
-    jqUnit.assertLeftHand(message, expected, JSON.parse(actual));
 };
 
 // all test request grades communicate with a port defined by the test configuration,

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -52,102 +52,165 @@ fluid.test.nexus.assertContainsComponent = function (componentRoot, parentPath, 
     jqUnit.assertValue(parentPath + " component contains " + childName, parent[childName]);
 };
 
+/**
+ * Assert that the object toTest contains a set of keys with given values.
+ * Can also be understood as "assert that the object expected is a subset of the object toTest".
+ * @param {Object} expected the expected keys and values.
+ * @param {Object} actual the object to test.
+ */
+fluid.test.nexus.assertKeyValues = function (expected, actual) {
+    for (var key in expected) {
+        var value = expected[key];
+        jqUnit.assertDeepEq(value, actual[key]);
+    }
+};
+
+fluid.defaults("fluid.test.nexus.readDefaultsRequest", {
+    gradeNames: ["kettle.test.request.http"],
+    path: "/defaults/%gradeName",
+    port: "{configuration}.options.serverPort",
+    method: "GET",
+    termMap: {
+        gradeName: "fill in construction options"
+    }
+});
+
+fluid.defaults("fluid.test.nexus.writeDefaultsRequest", {
+    gradeNames: ["kettle.test.request.http"],
+    path: "/defaults/%gradeName",
+    port: "{configuration}.options.serverPort",
+    method: "PUT",
+    termMap: {
+        gradeName: "fill in construction options"
+    }
+});
+
+fluid.defaults("fluid.test.nexus.readComponentRequest", {
+    gradeNames: ["kettle.test.request.http"],
+    path: "/components/%path",
+    port: "{configuration}.options.serverPort",
+    method: "GET",
+    termMap: {
+        path: "fill in construction options"
+    }
+});
+
+fluid.defaults("fluid.test.nexus.constructComponentRequest", {
+    gradeNames: ["kettle.test.request.http"],
+    path: "/components/%path",
+    port: "{configuration}.options.serverPort",
+    method: "PUT",
+    termMap: {
+        path: "fill in construction options"
+    }
+});
+
+fluid.defaults("fluid.test.nexus.destroyComponentRequest", {
+    gradeNames: ["kettle.test.request.http"],
+    path: "/components/%path",
+    port: "{configuration}.options.serverPort",
+    method: "DELETE",
+    termMap: {
+        path: "fill in construction options"
+    }
+});
+
 fluid.defaults("fluid.test.nexus.testCaseHolder", {
     gradeNames: "kettle.test.testCaseHolder",
     components: {
         readDefaultsRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.readDefaultsRequest",
             options: {
-                path: "/defaults/%gradeName",
-                port: "{configuration}.options.serverPort",
                 termMap: {
                     gradeName: "{tests}.options.testGradeName"
                 }
             }
         },
         readDefaultsSecondTimeRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.readDefaultsRequest",
             options: {
-                path: "/defaults/%gradeName",
-                port: "{configuration}.options.serverPort",
                 termMap: {
                     gradeName: "{tests}.options.testGradeName"
                 }
             }
         },
         readDefaultsThirdTimeRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.readDefaultsRequest",
             options: {
-                path: "/defaults/%gradeName",
-                port: "{configuration}.options.serverPort",
                 termMap: {
                     gradeName: "{tests}.options.testGradeName"
                 }
             }
         },
         writeDefaultsRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.writeDefaultsRequest",
             options: {
-                path: "/defaults/%gradeName",
-                port: "{configuration}.options.serverPort",
-                method: "PUT",
                 termMap: {
                     gradeName: "{tests}.options.testGradeName"
                 }
             }
         },
         writeDefaultsAgainRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.writeDefaultsRequest",
             options: {
-                path: "/defaults/%gradeName",
-                port: "{configuration}.options.serverPort",
-                method: "PUT",
                 termMap: {
                     gradeName: "{tests}.options.testGradeName"
                 }
             }
         },
         constructComponentRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.constructComponentRequest",
             options: {
-                path: "/components/%path",
-                port: "{configuration}.options.serverPort",
-                method: "PUT",
                 termMap: {
                     path: "{tests}.options.testComponentPath"
                 }
             }
         },
         constructComponentRequest2: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.constructComponentRequest",
             options: {
-                path: "/components/%path",
-                port: "{configuration}.options.serverPort",
-                method: "PUT",
                 termMap: {
                     path: "{tests}.options.testComponentPath2"
                 }
             }
         },
         destroyComponentRequest: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.destroyComponentRequest",
             options: {
-                path: "/components/%path",
-                port: "{configuration}.options.serverPort",
-                method: "DELETE",
                 termMap: {
                     path: "{tests}.options.testComponentPath"
                 }
             }
         },
         destroyComponentRequest2: {
-            type: "kettle.test.request.http",
+            type: "fluid.test.nexus.destroyComponentRequest",
             options: {
-                path: "/components/%path",
-                port: "{configuration}.options.serverPort",
-                method: "DELETE",
                 termMap: {
                     path: "{tests}.options.testComponentPath2"
+                }
+            }
+        },
+        readComponentRequest1: {
+            type: "fluid.test.nexus.readComponentRequest",
+            options: {
+                termMap: {
+                    path: "{tests}.options.testComponentPath"
+                }
+            }
+        },
+        readComponentRequest2: {
+            type: "fluid.test.nexus.readComponentRequest",
+            options: {
+                termMap: {
+                    path: "{tests}.options.testComponentPath"
+                }
+            }
+        },
+        readComponentRequest3: {
+            type: "fluid.test.nexus.readComponentRequest",
+            options: {
+                termMap: {
+                    path: "{tests}.options.testComponentPath"
                 }
             }
         }

--- a/tests/BindModelTests.js
+++ b/tests/BindModelTests.js
@@ -48,6 +48,8 @@ fluid.defaults("fluid.tests.nexus.bindModel.wsClient", {
     }
 });
 
+// TODO: FLUID-6504: test establishing a bind model before a component exists at a particular path
+
 // TODO: Test with multiple connected WebSocket clients
 
 // Note that these tests verify steps by peeking into the Nexus internal
@@ -84,13 +86,13 @@ fluid.tests.nexus.bindModel.testDefs = [
                 ]
             },
             {
-                func: "{constructComponentRequest}.send",
+                func: "{constructComponentRequest1}.send",
                 args: [fluid.tests.nexus.bindModel.componentOptions]
             },
             {
-                event: "{constructComponentRequest}.events.onComplete",
+                event: "{constructComponentRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{constructComponentRequest}", 200]
+                args: ["{constructComponentRequest1}", 200]
             },
             {
                 func: "fluid.tests.nexus.bindModel.registerModelListenerForPath",

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -45,7 +45,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
     {
         name: "Construct and Destroy Components",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 17,
+        expect: 21,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -81,6 +81,17 @@ fluid.tests.nexus.constructComponent.testDefs = [
                     "{tests}.options.testComponentPath2"
                 ]
             },
+            // Attempt to read component one
+            {
+                func: "{readComponentRequest1}.send",
+                args: []
+            },
+            // Expect 404 resource not found
+            {
+                event: "{readComponentRequest1}.events.onComplete",
+                listener: "fluid.test.nexus.assertStatusCode",
+                args: ["{readComponentRequest1}", 404]
+            },
             // Construct component one
             {
                 func: "{constructComponentRequest}.send",
@@ -99,6 +110,22 @@ fluid.tests.nexus.constructComponent.testDefs = [
                     "{tests}.options.testComponentPath",
                     fluid.tests.nexus.constructComponent.componentOptions1.model
                 ]
+            },
+            // Attempt to read component one
+            {
+                func: "{readComponentRequest2}.send",
+                args: []
+            },
+            // expect the response to contain model data, gradeNames, subcomponents
+            {
+                event: "{readComponentRequest2}.events.onComplete",
+                listener: "fluid.test.nexus.assertKeyValues",
+                args: [{
+                    typeName: "fluid.modelComponent",
+                    model: {
+                        "some.model\\path": "one"
+                    }
+                }, "{arguments}.0"]
             },
             // Construct component two
             {
@@ -177,6 +204,17 @@ fluid.tests.nexus.constructComponent.testDefs = [
                 event: "{destroyComponentRequest}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
                 args: ["{destroyComponentRequest}", 200]
+            },
+            // Attempt to read component one
+            {
+                func: "{readComponentRequest3}.send",
+                args: []
+            },
+            // Expect 404 resource not found
+            {
+                event: "{readComponentRequest3}.events.onComplete",
+                listener: "fluid.test.nexus.assertStatusCode",
+                args: ["{readComponentRequest3}", 404]
             },
             {
                 func: "fluid.test.nexus.assertNoComponentAtPath",

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -127,7 +127,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
                         model: {
                             "some.model\\path": "one"
                         }
-                    }, 
+                    },
                     "{arguments}.0"
                 ]
             },

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -45,7 +45,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
     {
         name: "Construct and Destroy Components",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 20,
+        expect: 22,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -119,16 +119,16 @@ fluid.tests.nexus.constructComponent.testDefs = [
             // expect the response to contain model data, gradeNames, subcomponents
             {
                 event: "{readComponentRequest2}.events.onComplete",
-                listener: "fluid.test.nexus.assertLeftHand",
+                listener: "fluid.test.nexus.verifyReadComponentResponse",
                 args: [
-                    "Component shell contains typeName and model data",
+                    "{arguments}.0",
+                    "{readComponentRequest2}",
                     {
                         typeName: "fluid.modelComponent",
                         model: {
                             "some.model\\path": "one"
                         }
-                    },
-                    "{arguments}.0"
+                    }
                 ]
             },
             // Construct component two

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -45,7 +45,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
     {
         name: "Construct and Destroy Components",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 21,
+        expect: 20,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -94,13 +94,13 @@ fluid.tests.nexus.constructComponent.testDefs = [
             },
             // Construct component one
             {
-                func: "{constructComponentRequest}.send",
+                func: "{constructComponentRequest1}.send",
                 args: [fluid.tests.nexus.constructComponent.componentOptions1]
             },
             {
-                event: "{constructComponentRequest}.events.onComplete",
+                event: "{constructComponentRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{constructComponentRequest}", 200]
+                args: ["{constructComponentRequest1}", 200]
             },
             {
                 func: "fluid.test.nexus.assertComponentModel",
@@ -119,13 +119,17 @@ fluid.tests.nexus.constructComponent.testDefs = [
             // expect the response to contain model data, gradeNames, subcomponents
             {
                 event: "{readComponentRequest2}.events.onComplete",
-                listener: "fluid.test.nexus.assertKeyValues",
-                args: [{
-                    typeName: "fluid.modelComponent",
-                    model: {
-                        "some.model\\path": "one"
-                    }
-                }, "{arguments}.0"]
+                listener: "fluid.test.nexus.assertLeftHand",
+                args: [
+                    "Component shell contains typeName and model data",
+                    {
+                        typeName: "fluid.modelComponent",
+                        model: {
+                            "some.model\\path": "one"
+                        }
+                    }, 
+                    "{arguments}.0"
+                ]
             },
             // Construct component two
             {
@@ -198,12 +202,12 @@ fluid.tests.nexus.constructComponent.testDefs = [
                 ]
             },
             {
-                func: "{destroyComponentRequest}.send"
+                func: "{destroyComponentRequest1}.send"
             },
             {
-                event: "{destroyComponentRequest}.events.onComplete",
+                event: "{destroyComponentRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{destroyComponentRequest}", 200]
+                args: ["{destroyComponentRequest1}", 200]
             },
             // Attempt to read component one
             {

--- a/tests/ReadDefaultsTests.js
+++ b/tests/ReadDefaultsTests.js
@@ -39,14 +39,14 @@ fluid.tests.nexus.readDefaults.testDefs = [
         testGradeName: "fluid.tests.nexus.readDefaults.testGrade",
         sequence: [
             {
-                func: "{readDefaultsRequest}.send"
+                func: "{readDefaultsRequest1}.send"
             },
             {
-                event: "{readDefaultsRequest}.events.onComplete",
+                event: "{readDefaultsRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.verifyReadDefaultsResponse",
                 args: [
                     "{arguments}.0",
-                    "{readDefaultsRequest}",
+                    "{readDefaultsRequest1}",
                     {
                         gradeNames: ["fluid.component", "fluid.tests.nexus.readDefaults.testGrade"],
                         model: {
@@ -68,16 +68,16 @@ fluid.tests.nexus.readDefaults.testDefs = [
         testGradeName: "fluid.tests.nexus.nonExistingGrade",
         sequence: [
             {
-                func: "{readDefaultsRequest}.send"
+                func: "{readDefaultsRequest1}.send"
             },
             {
-                event: "{readDefaultsRequest}.events.onComplete",
+                event: "{readDefaultsRequest1}.events.onComplete",
                 listener: "kettle.test.assertErrorResponse",
                 args: [{
                     message: "Read Defaults for non-existing grade returns 404",
                     errorTexts: "Grade not found",
                     string: "{arguments}.0",
-                    request: "{readDefaultsRequest}",
+                    request: "{readDefaultsRequest1}",
                     statusCode: 404
                 }]
             }

--- a/tests/WriteDefaultsTests.js
+++ b/tests/WriteDefaultsTests.js
@@ -74,37 +74,37 @@ fluid.tests.nexus.writeDefaults.testDefs = [
         testGradeName: "fluid.tests.nexus.writeDefaults.newGradeRemote",
         sequence: [
             {
-                func: "{readDefaultsRequest}.send"
+                func: "{readDefaultsRequest1}.send"
             },
             {
-                event: "{readDefaultsRequest}.events.onComplete",
+                event: "{readDefaultsRequest1}.events.onComplete",
                 listener: "kettle.test.assertErrorResponse",
                 args: [{
                     message: "Read Defaults returns 404 as we haven't created the new grade yet",
                     errorTexts: "Grade not found",
                     string: "{arguments}.0",
-                    request: "{readDefaultsRequest}",
+                    request: "{readDefaultsRequest1}",
                     statusCode: 404
                 }]
             },
             {
-                func: "{writeDefaultsRequest}.send",
+                func: "{writeDefaultsRequest1}.send",
                 args: [fluid.tests.nexus.writeDefaults.newGradeOptions]
             },
             {
-                event: "{writeDefaultsRequest}.events.onComplete",
+                event: "{writeDefaultsRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest}", 200]
+                args: ["{writeDefaultsRequest1}", 200]
             },
             {
-                func: "{readDefaultsSecondTimeRequest}.send"
+                func: "{readDefaultsRequest2}.send"
             },
             {
-                event: "{readDefaultsSecondTimeRequest}.events.onComplete",
+                event: "{readDefaultsRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.verifyReadDefaultsResponse",
                 args: [
                     "{arguments}.0",
-                    "{readDefaultsSecondTimeRequest}",
+                    "{readDefaultsRequest2}",
                     {
                         gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
                         model: {
@@ -114,23 +114,23 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                 ]
             },
             {
-                func: "{writeDefaultsAgainRequest}.send",
+                func: "{writeDefaultsRequest2}.send",
                 args: [fluid.tests.nexus.writeDefaults.updatedGradeOptions]
             },
             {
-                event: "{writeDefaultsAgainRequest}.events.onComplete",
+                event: "{writeDefaultsRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsAgainRequest}", 200]
+                args: ["{writeDefaultsRequest2}", 200]
             },
             {
-                func: "{readDefaultsThirdTimeRequest}.send"
+                func: "{readDefaultsRequest3}.send"
             },
             {
-                event: "{readDefaultsThirdTimeRequest}.events.onComplete",
+                event: "{readDefaultsRequest3}.events.onComplete",
                 listener: "fluid.test.nexus.verifyReadDefaultsResponse",
                 args: [
                     "{arguments}.0",
-                    "{readDefaultsThirdTimeRequest}",
+                    "{readDefaultsRequest3}",
                     {
                         gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
                         model: {
@@ -156,7 +156,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                 listener: "fluid.identity"
             },
             {
-                func: "{writeDefaultsRequest}.send",
+                func: "{writeDefaultsRequest1}.send",
                 args: [
                     "{badlyFormedJson}.resources.corruptJSON.resourceText",
                     {
@@ -167,7 +167,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                 ]
             },
             {
-                event: "{writeDefaultsRequest}.events.onComplete",
+                event: "{writeDefaultsRequest1}.events.onComplete",
                 listener: "kettle.test.assertErrorResponse",
                 args: [{
                     message: "Write Defaults returns 400 for badly formed JSON",
@@ -180,7 +180,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                     // https://issues.fluid.net/browse/GPII-2080
                     errorTexts: "Unexpected end of",
                     string: "{arguments}.0",
-                    request: "{writeDefaultsRequest}",
+                    request: "{writeDefaultsRequest1}",
                     statusCode: 400
                 }]
             }
@@ -202,16 +202,16 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             },
             {
                 funcName: "fluid.tests.nexus.writeDefaults.sendBadlyFormedInvokerGradeOptions",
-                args: ["{writeDefaultsRequest}"]
+                args: ["{writeDefaultsRequest1}"]
             },
             {
-                event: "{writeDefaultsRequest}.events.onComplete",
+                event: "{writeDefaultsRequest1}.events.onComplete",
                 listener: "kettle.test.assertErrorResponse",
                 args: [{
                     message: "Write Defaults returns 500 for badly formed grade",
                     errorTexts: "Badly-formed compact invoker record without matching parentheses: bad(",
                     string: "{arguments}.0",
-                    request: "{writeDefaultsRequest}",
+                    request: "{writeDefaultsRequest1}",
                     statusCode: 500
                 }]
             },
@@ -231,19 +231,19 @@ fluid.tests.nexus.writeDefaults.testDefs = [
         testGradeName: "fluid.tests.nexus.writeDefaults.newGradeRemote",
         sequence: [
             {
-                func: "{writeDefaultsRequest}.send",
+                func: "{writeDefaultsRequest1}.send",
                 args: [fluid.tests.nexus.writeDefaults.newGradeOptions]
             },
             {
-                event: "{writeDefaultsRequest}.events.onComplete",
+                event: "{writeDefaultsRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest}", 200]
+                args: ["{writeDefaultsRequest1}", 200]
             },
             {
-                func: "{readDefaultsRequest}.send"
+                func: "{readDefaultsRequest1}.send"
             },
             {
-                event: "{readDefaultsRequest}.events.onComplete",
+                event: "{readDefaultsRequest1}.events.onComplete",
                 listener: "fluid.tests.nexus.writeDefaults.rememberReadDefaultsResponse",
                 args: ["{arguments}.0", "{tests}"]
             },
@@ -251,7 +251,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                 funcName: "fluid.test.nexus.verifyReadDefaultsResponse",
                 args: [
                     "{tests}.readDefaultsResponseBody",
-                    "{readDefaultsRequest}",
+                    "{readDefaultsRequest1}",
                     {
                         gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
                         model: {
@@ -261,23 +261,23 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                 ]
             },
             {
-                func: "{writeDefaultsAgainRequest}.send",
+                func: "{writeDefaultsRequest2}.send",
                 args: ["{tests}.readDefaultsResponseGradeSpec"]
             },
             {
-                event: "{writeDefaultsAgainRequest}.events.onComplete",
+                event: "{writeDefaultsRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsAgainRequest}", 200]
+                args: ["{writeDefaultsRequest2}", 200]
             },
             {
-                func: "{readDefaultsSecondTimeRequest}.send"
+                func: "{readDefaultsRequest2}.send"
             },
             {
-                event: "{readDefaultsSecondTimeRequest}.events.onComplete",
+                event: "{readDefaultsRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.verifyReadDefaultsResponse",
                 args: [
                     "{arguments}.0",
-                    "{readDefaultsSecondTimeRequest}",
+                    "{readDefaultsRequest2}",
                     "{tests}.readDefaultsResponseGradeSpec"
                 ]
             }


### PR DESCRIPTION
Design justification for these API revisions are given at [this wiki page]( https://wiki.fluidproject.org/display/fluid/Nexus+API+revisions).