### PR TITLE
Fluid 6521: Use new kettle.request.http API for non-200 status codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "infusion-nexus",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "author": "fluid-project",
     "license": "BSD-3-Clause",
     "repository": "git@github.com:fluid-project/nexus.git",
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "infusion": "3.0.0-dev.20200214T151835Z.ab768289a.FLUID-6145",
-        "kettle": "ptcher/kettle#KETTLE-86"
+        "kettle": "1.14.0"
     },
     "devDependencies": {
         "eslint-config-fluid": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     },
     "dependencies": {
         "infusion": "3.0.0-dev.20200214T151835Z.ab768289a.FLUID-6145",
-        "kettle": "1.12.0"
+        "kettle": "ptcher/kettle#KETTLE-86"
     },
     "devDependencies": {
         "eslint-config-fluid": "1.4.0",

--- a/src/nexusGrades.js
+++ b/src/nexusGrades.js
@@ -93,7 +93,9 @@ fluid.defaults("fluid.nexus.writeDefaults.handler", {
 
 fluid.nexus.writeDefaults.handleRequest = function (gradeName, request) {
     fluid.defaults(gradeName, request.req.body);
-    request.events.onSuccess.fire();
+    request.events.onSuccess.fire(undefined, {
+        statusCode: 201
+    });
 };
 
 fluid.defaults("fluid.nexus.readComponent.handler", {
@@ -144,7 +146,9 @@ fluid.defaults("fluid.nexus.constructComponent.handler", {
 fluid.nexus.constructComponent.handleRequest = function (path, request, componentRoot) {
     var segs = fluid.pathUtil.parseEL(path);
     fluid.nexus.constructInContainer(componentRoot, segs, request.req.body);
-    request.events.onSuccess.fire();
+    request.events.onSuccess.fire(undefined, {
+        statusCode: 201
+    });
 };
 
 fluid.defaults("fluid.nexus.destroyComponent.handler", {
@@ -161,7 +165,9 @@ fluid.defaults("fluid.nexus.destroyComponent.handler", {
 fluid.nexus.destroyComponent.handleRequest = function (path, request, componentRoot) {
     var segs = fluid.pathUtil.parseEL(path);
     fluid.nexus.destroyInContainer(componentRoot, segs);
-    request.events.onSuccess.fire();
+    request.events.onSuccess.fire(undefined, {
+        statusCode: 204
+    });
 };
 
 fluid.defaults("fluid.nexus.bindModel.handler", {

--- a/src/nexusGrades.js
+++ b/src/nexusGrades.js
@@ -94,7 +94,10 @@ fluid.defaults("fluid.nexus.writeDefaults.handler", {
 fluid.nexus.writeDefaults.handleRequest = function (gradeName, request) {
     fluid.defaults(gradeName, request.req.body);
     request.events.onSuccess.fire(undefined, {
-        statusCode: 201
+        statusCode: 201,
+        headers: {
+            "Content-Location": "/defaults/" + gradeName
+        }
     });
 };
 
@@ -147,7 +150,10 @@ fluid.nexus.constructComponent.handleRequest = function (path, request, componen
     var segs = fluid.pathUtil.parseEL(path);
     fluid.nexus.constructInContainer(componentRoot, segs, request.req.body);
     request.events.onSuccess.fire(undefined, {
-        statusCode: 201
+        statusCode: 201,
+        headers: {
+            "Content-Location": "/components/" + path
+        }
     });
 };
 

--- a/src/nexusGrades.js
+++ b/src/nexusGrades.js
@@ -94,10 +94,7 @@ fluid.defaults("fluid.nexus.writeDefaults.handler", {
 fluid.nexus.writeDefaults.handleRequest = function (gradeName, request) {
     fluid.defaults(gradeName, request.req.body);
     request.events.onSuccess.fire(undefined, {
-        statusCode: 201,
-        headers: {
-            "Content-Location": "/defaults/" + gradeName
-        }
+        statusCode: 201
     });
 };
 
@@ -150,10 +147,7 @@ fluid.nexus.constructComponent.handleRequest = function (path, request, componen
     var segs = fluid.pathUtil.parseEL(path);
     fluid.nexus.constructInContainer(componentRoot, segs, request.req.body);
     request.events.onSuccess.fire(undefined, {
-        statusCode: 201,
-        headers: {
-            "Content-Location": "/components/" + path
-        }
+        statusCode: 201
     });
 };
 

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -43,10 +43,11 @@ fluid.test.nexus.assertHTTPResponse = function (body, request, expected) {
     if (expected.headers !== undefined) {
         for (var key in expected.headers) {
             var expectedValue = expected.headers[key];
+            var receivedValue = response.headers[key.toLowerCase()];
             if (expectedValue === fluid.NO_VALUE) {
-                jqUnit.assertUndefined("Response header " + key + " is undefined", response.headers[key.toLowerCase()]);
+                jqUnit.assertUndefined("Response header " + key + " is undefined", receivedValue);
             } else {
-                jqUnit.assertTrue("Response has header " + key + " with value containing " + expectedValue, response.headers[key.toLowerCase()].indexOf(expectedValue) !== -1);
+                jqUnit.assertTrue("Response has header " + key + " with value containing " + expectedValue, receivedValue.includes(expectedValue));
             }
         }
     }

--- a/src/test/nexusTestUtils.js
+++ b/src/test/nexusTestUtils.js
@@ -22,31 +22,34 @@ fluid.test.nexus.assertStatusCode = function (request, statusCode) {
     jqUnit.assertEquals("Response has status code " + statusCode, statusCode, response.statusCode);
 };
 
-fluid.test.nexus.verifyReadDefaultsResponse = function (body, request, expectedGradeSpec) {
-    // TODO: Switch over to the new assertion function of KETTLE-39
-    var responseGradeSpec = JSON.parse(body);
-    var response = request.nativeResponse;
-    jqUnit.assertEquals("Response has status code 200", 200, response.statusCode);
-    jqUnit.assertTrue("Response has JSON content-type",
-                      response.headers["content-type"].indexOf("application/json") === 0);
-    jqUnit.assertLeftHand("Response has expected grade specification", expectedGradeSpec, responseGradeSpec);
-};
-
-
 /**
- * Verify that a response to the component reading endpoint is well-formed and has the expected content.
+ * Verify HTTP response body and metadata specified as an object.
  * @param {String} body the body of the HTTP response.
  * @param {kettle.request.http} request the component representing the HTTP response.
- * @param {Object} expectedComponentMaterial the expected content of the response body.
+ * @param {Object} expected the expected content of the response body. Contains three optional keys, responseBody, statusCode, and headers. If responseBody is specified, we assert that the actual body is a subset of it. If statusCode is specified, we assert that the response status code is equal to it. For each key-value pair in headers, we assert that the response has a header entry whose value contains the specified value (e.g. the expected header {"content-type": "application/json"} will match the actual header {"content-type": "application/json; charset=UTF-8"}). responseBody and header values may be fluid.NO_VALUE to assert that they are undefined in the response.
  */
-fluid.test.nexus.verifyReadComponentResponse = function (body, request, expectedComponentMaterial) {
-    var responseComponentMaterial = JSON.parse(body);
+fluid.test.nexus.assertHTTPResponse = function (body, request, expected) {
     var response = request.nativeResponse;
-    jqUnit.assertEquals("Response has status code 200", 200, response.statusCode);
-    jqUnit.assertTrue("Response has JSON content-type",
-                      response.headers["content-type"].indexOf("application/json") === 0);
-    jqUnit.assertLeftHand("Response has expected component material", expectedComponentMaterial,
-    responseComponentMaterial);
+    if (expected.responseBody !== undefined) {
+        if (expected.responseBody === fluid.NO_VALUE) {
+            jqUnit.assertEquals("Response has no body", "", body);
+        } else {
+            jqUnit.assertLeftHand("Response body has expected value", expected.responseBody, JSON.parse(body));
+        }
+    }
+    if (expected.statusCode !== undefined) {
+        jqUnit.assertEquals("Response has status code " + expected.statusCode, expected.statusCode, response.statusCode);
+    }
+    if (expected.headers !== undefined) {
+        for (var key in expected.headers) {
+            var expectedValue = expected.headers[key];
+            if (expectedValue === fluid.NO_VALUE) {
+                jqUnit.assertUndefined("Response header " + key + " is undefined", response.headers[key.toLowerCase()]);
+            } else {
+                jqUnit.assertTrue("Response has header " + key + " with value containing " + expectedValue, response.headers[key.toLowerCase()].indexOf(expectedValue) !== -1);
+            }
+        }
+    }
 };
 
 fluid.test.nexus.assertNoComponentAtPath = function (message, componentRoot, path) {

--- a/tests/BindModelTests.js
+++ b/tests/BindModelTests.js
@@ -61,7 +61,7 @@ fluid.tests.nexus.bindModel.testDefs = [
     {
         name: "Bind Model",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 13,
+        expect: 16,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -106,8 +106,15 @@ fluid.tests.nexus.bindModel.testDefs = [
             },
             {
                 event: "{constructComponentRequest1}.events.onComplete",
-                listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{constructComponentRequest1}", 201]
+                listener: "fluid.test.nexus.assertHTTPResponse",
+                args: ["{arguments}.0", "{constructComponentRequest1}", {
+                    statusCode: 201,
+                    headers: {
+                        "content-type": fluid.NO_VALUE,
+                        "content-length": 0
+                    },
+                    responseBody: fluid.NO_VALUE
+                }]
             },
             {
                 func: "fluid.tests.nexus.bindModel.registerModelListenerForPath",

--- a/tests/BindModelTests.js
+++ b/tests/BindModelTests.js
@@ -107,7 +107,7 @@ fluid.tests.nexus.bindModel.testDefs = [
             {
                 event: "{constructComponentRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{constructComponentRequest1}", 200]
+                args: ["{constructComponentRequest1}", 201]
             },
             {
                 func: "fluid.tests.nexus.bindModel.registerModelListenerForPath",

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -10,10 +10,6 @@ https://raw.githubusercontent.com/fluid-project/infusion-nexus/master/LICENSE.tx
 
 /* eslint-env node */
 
-// TODO: test that PUT responses *do not* have JSON headers
-//       in fact, anything with a non-extant response body should not have a content type
-// Current issue is that I need a workable way to specify that particular values are undefined
-
 "use strict";
 
 var fluid = require("infusion"),

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -49,7 +49,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
     {
         name: "Construct and Destroy Components",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 34,
+        expect: 32,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -108,8 +108,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
                     statusCode: 201,
                     headers: {
                         "content-type": fluid.NO_VALUE,
-                        "content-length": 0,
-                        "content-location": "/components/nexusConstructTestsComponentOne"
+                        "content-length": 0
                     },
                     responseBody: fluid.NO_VALUE
                 }]
@@ -165,19 +164,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
                     statusCode: 201,
                     headers: {
                         "content-type": fluid.NO_VALUE,
-                        "content-length": 0,
-                        "content-location": {
-                            expander: {
-                                func: "fluid.stringTemplate",
-                                args: [
-                                    "%parent.%child",
-                                    {
-                                        parent: "{tests}.options.testComponentPath",
-                                        child: "{tests}.options.testComponentName2"
-                                    }
-                                ]
-                            }
-                        }
+                        "content-length": 0
                     },
                     responseBody: fluid.NO_VALUE
                 }]

--- a/tests/ConstructAndDestroyComponentTests.js
+++ b/tests/ConstructAndDestroyComponentTests.js
@@ -100,7 +100,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
             {
                 event: "{constructComponentRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{constructComponentRequest1}", 200]
+                args: ["{constructComponentRequest1}", 201]
             },
             {
                 func: "fluid.test.nexus.assertComponentModel",
@@ -147,7 +147,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
             {
                 event: "{constructComponentRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{constructComponentRequest2}", 200]
+                args: ["{constructComponentRequest2}", 201]
             },
             {
                 func: "fluid.test.nexus.assertComponentModel",
@@ -173,7 +173,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
             {
                 event: "{destroyComponentRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{destroyComponentRequest2}", 200]
+                args: ["{destroyComponentRequest2}", 204]
             },
             {
                 func: "fluid.test.nexus.assertNoComponentAtPath",
@@ -207,7 +207,7 @@ fluid.tests.nexus.constructComponent.testDefs = [
             {
                 event: "{destroyComponentRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{destroyComponentRequest1}", 200]
+                args: ["{destroyComponentRequest1}", 204]
             },
             // Attempt to read component one
             {

--- a/tests/ReadDefaultsTests.js
+++ b/tests/ReadDefaultsTests.js
@@ -43,16 +43,23 @@ fluid.tests.nexus.readDefaults.testDefs = [
             },
             {
                 event: "{readDefaultsRequest1}.events.onComplete",
-                listener: "fluid.test.nexus.verifyReadDefaultsResponse",
+                listener: "fluid.test.nexus.assertHTTPResponse",
                 args: [
                     "{arguments}.0",
                     "{readDefaultsRequest1}",
                     {
-                        gradeNames: ["fluid.component", "fluid.tests.nexus.readDefaults.testGrade"],
-                        model: {
-                            name1: "hello world"
+                        statusCode: 200,
+                        headers: {
+                            "content-type": "application/json"
+                        },
+                        responseBody: {
+                            gradeNames: ["fluid.component", "fluid.tests.nexus.readDefaults.testGrade"],
+                            model: {
+                                name1: "hello world"
+                            }
                         }
                     }
+
                 ]
             }
         ]

--- a/tests/WriteDefaultsTests.js
+++ b/tests/WriteDefaultsTests.js
@@ -94,7 +94,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             {
                 event: "{writeDefaultsRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest1}", 200]
+                args: ["{writeDefaultsRequest1}", 201]
             },
             {
                 func: "{readDefaultsRequest2}.send"
@@ -120,7 +120,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             {
                 event: "{writeDefaultsRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest2}", 200]
+                args: ["{writeDefaultsRequest2}", 201]
             },
             {
                 func: "{readDefaultsRequest3}.send"
@@ -237,7 +237,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             {
                 event: "{writeDefaultsRequest1}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest1}", 200]
+                args: ["{writeDefaultsRequest1}", 201]
             },
             {
                 func: "{readDefaultsRequest1}.send"
@@ -267,7 +267,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             {
                 event: "{writeDefaultsRequest2}.events.onComplete",
                 listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest2}", 200]
+                args: ["{writeDefaultsRequest2}", 201]
             },
             {
                 func: "{readDefaultsRequest2}.send"

--- a/tests/WriteDefaultsTests.js
+++ b/tests/WriteDefaultsTests.js
@@ -66,7 +66,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
     {
         name: "Write Defaults with good grade options and verify update to the grade",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 19,
+        expect: 17,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -98,8 +98,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                     statusCode: 201,
                     headers: {
                         "content-type": fluid.NO_VALUE,
-                        "content-length": 0,
-                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                        "content-length": 0
                     },
                     responseBody: fluid.NO_VALUE
                 }]
@@ -138,8 +137,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                     statusCode: 201,
                     headers: {
                         "content-type": fluid.NO_VALUE,
-                        "content-length": 0,
-                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                        "content-length": 0
                     },
                     responseBody: fluid.NO_VALUE
                 }]
@@ -251,7 +249,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
     {
         name: "Send a Read Defaults response back to Write Defaults and verify that the grade is stable",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 14,
+        expect: 12,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -269,8 +267,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                     statusCode: 201,
                     headers: {
                         "content-type": fluid.NO_VALUE,
-                        "content-length": 0,
-                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                        "content-length": 0
                     },
                     responseBody: fluid.NO_VALUE
                 }]
@@ -311,8 +308,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                     statusCode: 201,
                     headers: {
                         "content-type": fluid.NO_VALUE,
-                        "content-length": 0,
-                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                        "content-length": 0
                     },
                     responseBody: fluid.NO_VALUE
                 }]

--- a/tests/WriteDefaultsTests.js
+++ b/tests/WriteDefaultsTests.js
@@ -66,7 +66,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
     {
         name: "Write Defaults with good grade options and verify update to the grade",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 11,
+        expect: 19,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -93,22 +93,36 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             },
             {
                 event: "{writeDefaultsRequest1}.events.onComplete",
-                listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest1}", 201]
+                listener: "fluid.test.nexus.assertHTTPResponse",
+                args: ["{arguments}.0", "{writeDefaultsRequest1}", {
+                    statusCode: 201,
+                    headers: {
+                        "content-type": fluid.NO_VALUE,
+                        "content-length": 0,
+                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                    },
+                    responseBody: fluid.NO_VALUE
+                }]
             },
             {
                 func: "{readDefaultsRequest2}.send"
             },
             {
                 event: "{readDefaultsRequest2}.events.onComplete",
-                listener: "fluid.test.nexus.verifyReadDefaultsResponse",
+                listener: "fluid.test.nexus.assertHTTPResponse",
                 args: [
                     "{arguments}.0",
                     "{readDefaultsRequest2}",
                     {
-                        gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
-                        model: {
-                            name1: "hello world"
+                        statusCode: 200,
+                        headers: {
+                            "content-type": "application/json"
+                        },
+                        responseBody: {
+                            gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
+                            model: {
+                                name1: "hello world"
+                            }
                         }
                     }
                 ]
@@ -119,22 +133,36 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             },
             {
                 event: "{writeDefaultsRequest2}.events.onComplete",
-                listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest2}", 201]
+                listener: "fluid.test.nexus.assertHTTPResponse",
+                args: ["{arguments}.0", "{writeDefaultsRequest2}", {
+                    statusCode: 201,
+                    headers: {
+                        "content-type": fluid.NO_VALUE,
+                        "content-length": 0,
+                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                    },
+                    responseBody: fluid.NO_VALUE
+                }]
             },
             {
                 func: "{readDefaultsRequest3}.send"
             },
             {
                 event: "{readDefaultsRequest3}.events.onComplete",
-                listener: "fluid.test.nexus.verifyReadDefaultsResponse",
+                listener: "fluid.test.nexus.assertHTTPResponse",
                 args: [
                     "{arguments}.0",
                     "{readDefaultsRequest3}",
                     {
-                        gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
-                        model: {
-                            updatedGrade: true
+                        statusCode: 200,
+                        headers: {
+                            "content-type": "application/json"
+                        },
+                        responseBody: {
+                            gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
+                            model: {
+                                updatedGrade: true
+                            }
                         }
                     }
                 ]
@@ -223,7 +251,7 @@ fluid.tests.nexus.writeDefaults.testDefs = [
     {
         name: "Send a Read Defaults response back to Write Defaults and verify that the grade is stable",
         gradeNames: "fluid.test.nexus.testCaseHolder",
-        expect: 8,
+        expect: 14,
         config: {
             configName: "fluid.tests.nexus.config",
             configPath: "%infusion-nexus/tests/configs"
@@ -236,8 +264,16 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             },
             {
                 event: "{writeDefaultsRequest1}.events.onComplete",
-                listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest1}", 201]
+                listener: "fluid.test.nexus.assertHTTPResponse",
+                args: ["{arguments}.0", "{writeDefaultsRequest1}", {
+                    statusCode: 201,
+                    headers: {
+                        "content-type": fluid.NO_VALUE,
+                        "content-length": 0,
+                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                    },
+                    responseBody: fluid.NO_VALUE
+                }]
             },
             {
                 func: "{readDefaultsRequest1}.send"
@@ -248,14 +284,18 @@ fluid.tests.nexus.writeDefaults.testDefs = [
                 args: ["{arguments}.0", "{tests}"]
             },
             {
-                funcName: "fluid.test.nexus.verifyReadDefaultsResponse",
+                funcName: "fluid.test.nexus.assertHTTPResponse",
                 args: [
                     "{tests}.readDefaultsResponseBody",
                     "{readDefaultsRequest1}",
                     {
-                        gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
-                        model: {
-                            name1: "hello world"
+                        statusCode: 200,
+                        "content-type": "application/json",
+                        responseBody: {
+                            gradeNames: ["fluid.component", "fluid.tests.nexus.writeDefaults.newGradeRemote"],
+                            model: {
+                                name1: "hello world"
+                            }
                         }
                     }
                 ]
@@ -266,19 +306,31 @@ fluid.tests.nexus.writeDefaults.testDefs = [
             },
             {
                 event: "{writeDefaultsRequest2}.events.onComplete",
-                listener: "fluid.test.nexus.assertStatusCode",
-                args: ["{writeDefaultsRequest2}", 201]
+                listener: "fluid.test.nexus.assertHTTPResponse",
+                args: ["{arguments}.0", "{writeDefaultsRequest2}", {
+                    statusCode: 201,
+                    headers: {
+                        "content-type": fluid.NO_VALUE,
+                        "content-length": 0,
+                        "content-location": "/defaults/fluid.tests.nexus.writeDefaults.newGradeRemote"
+                    },
+                    responseBody: fluid.NO_VALUE
+                }]
             },
             {
                 func: "{readDefaultsRequest2}.send"
             },
             {
                 event: "{readDefaultsRequest2}.events.onComplete",
-                listener: "fluid.test.nexus.verifyReadDefaultsResponse",
+                listener: "fluid.test.nexus.assertHTTPResponse",
                 args: [
                     "{arguments}.0",
                     "{readDefaultsRequest2}",
-                    "{tests}.readDefaultsResponseGradeSpec"
+                    {
+                        statusCode: 200,
+                        "content-type": "application/json",
+                        responseBody: "{tests}.readDefaultsResponseGradeSpec"
+                    }
                 ]
             }
         ]


### PR DESCRIPTION
This PR simply updates the Nexus grades and tests to utilize the extended request resolution API introduced in [KETTLE-86](https://issues.fluidproject.org/browse/KETTLE-86). Once the KETTLE-86 PR has been merged, this can be finalized with an incremented version number and a proper dependency in `package.json`.